### PR TITLE
Let http.url tag adhere to the semantic standard

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -10,10 +10,12 @@ export default function middleware(options = {}) {
     const span = tracer.startSpan(pathname, {childOf: wireCtx});
     span.logEvent("request_received");
 
+    const fullUrl = req.protocol + '://' + req.get('host') + req.originalUrl;
+
     // include some useful tags on the trace
     span.setTag("http.method", req.method);
     span.setTag("span.kind", "server");
-    span.setTag("http.url", req.url);
+    span.setTag("http.url", fullUrl);
 
     // include trace ID in headers so that we can debug slow requests we see in
     // the browser by looking up the trace ID found in response headers


### PR DESCRIPTION
I noticed when using this library that the `http.url` tag is always just filled out with the path after the base URL.
According to the Semantic Convention of OpenTracing (and also the newer one from OpenTelemetry) the `http.url` tag has to be filled with the full URI:

> Excerpt below taken from https://github.com/opentracing/specification/blob/master/semantic_conventions.md 
> http.url | string | URL of the request being handled in this segment of the trace, in standard URI format. E.g., "https://domain.net/path/to?resource=here"
> -- | -- | --

This PR changes this behavior by feeding the concatenated full URL to the `http.url` tag.